### PR TITLE
Remove `untilBuild` option so that the plugin will work with future IDE releases

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("231")
-        untilBuild.set("242.*")
+        untilBuild.set(provider { null })
     }
 
     publishPlugin {


### PR DESCRIPTION
 We can state that "there is no expiry" for the supported IDE of this plugin
by removing the `untilBuild` setting. This does not guarantee that the plugin 
will _work_ with future IDE releases,  only that it will not be pre-emptively 
disabled on a new release.

[Related Docs](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-tasks.html#patchPluginXml-untilBuild)